### PR TITLE
How to use の項を、デプロイとカスタムドメイン設定に分ける

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,18 @@ Use Netlify to return HTTP status code 410 for all accesses.
 
 ## How to use
 
+### Deploy to Netilfy
+
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cyber-gene/netlify-410)
+
+Or manually create a site on Netlify.
 
 1. Fork this repository.
 1. Create new site in Netlify.
 1. Setting and deploy site. Basic build settings do not need to be set.
+
+### Custom domain setting
+
 1. Custom domain settings in Netlify. And add a record to the DNS server you are using.
 1. After adding a record to your DNS, a TSL certificate will be automatically issued and you will be able to communicate over HTTPS.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -4,17 +4,23 @@
 
 Netlify を使用し、全ての HTTP アクセスに HTTP ステータスコード 410 を返します。
 
-## How to use
+## 使い方
+
+### Netlify にデプロイする
 
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/cyber-gene/netlify-410)
+
+手動で Netlify にデプロイすることもできます。
 
 1. このリポジトリをフォークします。
 1. フォークしたリポジトリから、Netlify で新しいサイトを作成します。
 1. サイト設定、デプロイ設定を行います。Basic build settings には何も入力する必要はありません。
+
+### カスタムドメイン設定
 1. Netlify で Custom domain の設定を行います。使用しているDNSサービスにレコードを追加します。
 1. レコード追加が Netlify 側で確認が出来たら、サーバー証明書が自動的に作成され、 HTTPS でサイトにアクセス出来るようになります。
 
-## Sample site
+## サンプルサイト
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e5b953ea-0d12-4ec9-8720-6d98dd2153d1/deploy-status)](https://app.netlify.com/sites/sharp-einstein-854dcc/deploys)
 


### PR DESCRIPTION
ワンクリックデプロイで出来ることと、手動で設定する部分が分かりにくかったので、項を分割した。